### PR TITLE
feat: implementa CRUD de [professores]

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,9 @@ app.use((req, res, next) => {
 const Alunos = require("./routes/alunos");
 app.use(Alunos);
 
+const Professores = require("./routes/professores");
+app.use("/professores", professoresRouter);
+
 app.listen(3000, () => {
     console.log("Rodando em http://localhost:3000");
 });

--- a/routes/professores.js
+++ b/routes/professores.js
@@ -1,0 +1,62 @@
+const express = require("express");
+const router = express.Router();
+
+let professores = [
+  { id: 1, nome: "Carlos Pereira", disciplina: "Matemática" },
+  { id: 2, nome: "Ana Lima", disciplina: "História" }
+];
+
+
+router.get("/", (req, res) => {
+  res.json(professores);
+});
+
+router.get("/:id", (req, res) => {
+  const professor = professores.find(p => p.id === parseInt(req.params.id));
+  if (!professor) return res.status(404).json({ error: "Professor não encontrado" });
+  res.json(professor);
+});
+
+
+router.post("/", (req, res) => {
+  const { nome, disciplina } = req.body;
+
+  if (!nome || !disciplina) {
+    return res.status(400).json({ error: "Nome e disciplina são obrigatórios" });
+  }
+
+  if (professores.some(p => p.nome === nome && p.disciplina === disciplina)) {
+    return res.status(400).json({ error: "Professor já cadastrado" });
+  }
+
+  const novoProfessor = {
+    id: professores.length + 1,
+    nome,
+    disciplina
+  };
+
+  professores.push(novoProfessor);
+  res.status(201).json(novoProfessor);
+});
+
+
+router.put("/:id", (req, res) => {
+  const professor = professores.find(p => p.id === parseInt(req.params.id));
+  if (!professor) return res.status(404).json({ error: "Professor não encontrado" });
+
+  const { nome, disciplina } = req.body;
+  if (nome) professor.nome = nome;
+  if (disciplina) professor.disciplina = disciplina;
+
+  res.json(professor);
+});
+
+router.delete("/:id", (req, res) => {
+  const index = professores.findIndex(p => p.id === parseInt(req.params.id));
+  if (index === -1) return res.status(404).json({ error: "Professor não encontrado" });
+
+  const removido = professores.splice(index, 1);
+  res.json(removido[0]);
+});
+
+module.exports = router;


### PR DESCRIPTION
Foi implementada uma API REST em Node.js com Express, que permite gerenciar uma lista de professores em memória. A API possibilita realizar operações de CRUD (Create, Read, Update, Delete):

Listar todos os professores (GET /professores) – Retorna a lista completa de professores cadastrados.

Buscar professor por ID (GET /professores/:id) – Retorna os dados de um professor específico pelo seu ID.

Cadastrar professor (POST /professores) – Permite adicionar um novo professor, garantindo que nome e disciplina sejam informados e que não exista duplicidade.

Atualizar professor (PUT /professores/:id) – Permite alterar os dados de um professor já existente.

Excluir professor (DELETE /professores/:id) – Remove um professor da lista pelo ID.